### PR TITLE
Sample test and training subsets stochastically

### DIFF
--- a/assignment1/utils.py
+++ b/assignment1/utils.py
@@ -3,6 +3,7 @@ import mnist
 import numpy as np
 import matplotlib.pyplot as plt
 
+np.random.seed(0)
 
 def batch_loader(
         X: np.ndarray, Y: np.ndarray,
@@ -56,18 +57,35 @@ def binary_prune_dataset(class1: int, class2: int,
     return X[mask_total], Y_binary[mask_total]
 
 
-def load_binary_dataset(class1: int, class2: int):
+def load_binary_dataset(class1: int, class2: int, train_size: int = 18000, test_size: int = 2000, sample_stochastic: bool = True):
     """
     Loads, prunes and splits the dataset into train, and validation.
+    Args:
+        train_size: Number of training samples
+        test_size: Number of validation samples
+        sample_stochastic: If True, the subset is sampled stochastically.
+
+    Returns:
+        X_train: images of shape [train_size, 784] in the range (0, 255)
+        Y_train: labels of shape [train_size]
+        X_val: images of shape [test_size, 784] in the range (0, 255)
+        Y_val: labels of shape [test_size]
     """
-    train_size = 18000
-    val_size = 2000
     X_train, Y_train, X_val, Y_val = mnist.load()
 
-    # First 20000 images from train set
-    X_train, Y_train = X_train[:train_size], Y_train[:train_size]
-    # Last 2000 images from test set
-    X_val, Y_val = X_val[:val_size], Y_val[:val_size]
+    if stochastic:
+        train_idx = np.random.choice(X_train.shape[0], train_size, replace=False)
+        val_idx = np.random.choice(X_val.shape[0], test_size, replace=False)
+    else:
+        # Default to first 'train_size' of train set images for training
+        # and last 'test_size' from test set images for validation
+        train_idx = np.arange(train_size)
+        val_idx = np.arange(X_val.shape[0] - test_size, X_val.shape[0])
+
+    # Sub set sampling
+    X_train, Y_train = X_train[train_idx], Y_train[train_idx]
+    X_val, Y_val = X_val[val_idx], Y_val[val_idx]
+
     X_train, Y_train = binary_prune_dataset(
         class1, class2, X_train, Y_train
     )
@@ -84,18 +102,35 @@ def load_binary_dataset(class1: int, class2: int):
     return X_train, Y_train, X_val, Y_val
 
 
-def load_full_mnist():
+def load_full_mnist(train_size: int = 18000, test_size: int = 2000, sample_stochastic: bool = True):
     """
     Loads and splits the dataset into train, validation and test.
+    Args:
+        train_size: Number of training samples
+        test_size: Number of validation samples
+        sample_stochastic: If True, the subset is sampled stochastically.
+
+    Returns:
+        X_train: images of shape [train_size, 784] in the range (0, 255)
+        Y_train: labels of shape [train_size]
+        X_val: images of shape [test_size, 784] in the range (0, 255)
+        Y_val: labels of shape [test_size]
     """
-    train_size = 18000
-    test_size = 2000
     X_train, Y_train, X_val, Y_val = mnist.load()
 
-    # First 20000 images from train set
-    X_train, Y_train = X_train[:train_size], Y_train[:train_size]
-    # Last 2000 images from test set
-    X_val, Y_val = X_val[-test_size:], Y_val[-test_size:]
+    if stochastic:
+        train_idx = np.random.choice(X_train.shape[0], train_size, replace=False)
+        val_idx = np.random.choice(X_val.shape[0], test_size, replace=False)
+    else:
+        # Default to first 'train_size' of train set images for training
+        # and last 'test_size' from test set images for validation
+        train_idx = np.arange(train_size)
+        val_idx = np.arange(X_val.shape[0] - test_size, X_val.shape[0])
+
+    # Sub set sampling
+    X_train, Y_train = X_train[train_idx], Y_train[train_idx]
+    X_val, Y_val = X_val[val_idx], Y_val[val_idx]
+
     # Reshape to (N, 1)
     Y_train = Y_train.reshape(-1, 1)
     Y_val = Y_val.reshape(-1, 1)


### PR DESCRIPTION
The current implementation of `load_full_mnist()` loads a skewed subset of MNIST for validation, giving the impression that training is somehow doing way better on most unseen data as compared to the actual training data.

As is, the validation set consists of the 2000 _last samples_ of the original MNIST test set. Those 2000 samples do not span the _real_ domain represented by the full test set of 10000 samples. leading to these seemingly impressive validation accuracies and losses.

Optimally, students should use the full sets - but, as that may not be computationally ideal for students in general, I've made this change to how the subsets are sampled. The addition simply adds an option to sample stochastically without replacement from the whole original dataset (both training and test). I select `train_size` (defaults to 18000) indices in [0-59999] and `test_size` (defaults to 2000) indices in [0-9999] when stochastic sampling is turned on.
Otherwise the same sequential sampling is used as before, using training set indices [0-`train_size`] and [(10000-`test_size`)-9999].

Then these index-arrays are instead used to sample from the original datasets.


As with other random-dependent parts of the code, I have seeded the random to help in reproducibility for students.


|          |   Accuracy  progression  |
|-------|---------|
|  Sequential sub-set sampling (current state) |  ![task3b_softmax_train_accuracy](https://user-images.githubusercontent.com/2846061/151804745-509c94e1-55c1-4768-9498-d01d16a0ff4f.png)    |
|   Stochastic sub-set sampling (suggested addition)   |  ![task3b_softmax_train_accuracy_stochastic](https://user-images.githubusercontent.com/2846061/151804749-2c8b99dd-76e4-4e2e-a7b8-b4b5c5389cfd.png) |

|          |   Loss  progression  |
|-------|---------|
|  Sequential sub-set sampling (current state) |  ![task3b_softmax_train_loss](https://user-images.githubusercontent.com/2846061/151804750-0781749c-7f53-47c6-81f4-aa663a9102f7.png)    |
|   Stochastic sub-set sampling (suggested addition)   |  ![task3b_softmax_train_loss_stochastic](https://user-images.githubusercontent.com/2846061/151804752-cd524dfa-39cc-4414-880d-ae6e914ff169.png) |


All in all, this turned out to be a nice deep dive into the importance of what data we use and how. - kind of similar to the importance of data shuffling within mini-batch sampling. 

So maybe there's a lesson there for future students of the course too?
